### PR TITLE
feat: aggregate functions and GROUP BY for the table query API

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jmoiron/sqlx"
 
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // QueryExecutor is the common interface satisfied by both *sqlx.DB and *sqlx.Tx,
@@ -26,9 +27,11 @@ type QueryExecutor interface {
 type SelectRequest struct {
 	Table      string
 	Fields     []string
+	Projection []query.SelectItem // structured SELECT list (plain columns and/or aggregates); takes precedence over Fields when set
 	Filter     string
 	FilterArgs []interface{}
 	Order      string
+	GroupBy    []string
 	Limit      int
 	Offset     int
 	Cursor     string
@@ -234,7 +237,7 @@ func sanitizeURLDSN(dsn string) string {
 
 // SchemaChange represents a table alteration.
 type SchemaChange struct {
-	Type       string        // "add_column", "drop_column", "rename_column", "modify_column"
+	Type       string // "add_column", "drop_column", "rename_column", "modify_column"
 	Column     string
 	NewName    string        // for rename
 	Definition *model.Column // for add/modify

--- a/internal/connector/mssql/query_builder.go
+++ b/internal/connector/mssql/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -25,15 +26,7 @@ func (c *MSSQLConnector) BuildSelect(_ context.Context, req connector.SelectRequ
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause
 	b.WriteString(" FROM ")
@@ -45,6 +38,12 @@ func (c *MSSQLConnector) BuildSelect(_ context.Context, req connector.SelectRequ
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause (required for OFFSET/FETCH NEXT)

--- a/internal/connector/mysql/query_builder.go
+++ b/internal/connector/mysql/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -23,15 +24,7 @@ func (c *MySQLConnector) BuildSelect(_ context.Context, req connector.SelectRequ
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause
 	b.WriteString(" FROM ")
@@ -43,6 +36,12 @@ func (c *MySQLConnector) BuildSelect(_ context.Context, req connector.SelectRequ
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause

--- a/internal/connector/oracle/query_builder.go
+++ b/internal/connector/oracle/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -25,15 +26,7 @@ func (c *OracleConnector) BuildSelect(_ context.Context, req connector.SelectReq
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause
 	b.WriteString(" FROM ")
@@ -45,6 +38,12 @@ func (c *OracleConnector) BuildSelect(_ context.Context, req connector.SelectReq
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause

--- a/internal/connector/postgres/query_builder.go
+++ b/internal/connector/postgres/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -24,15 +25,7 @@ func (c *PostgresConnector) BuildSelect(_ context.Context, req connector.SelectR
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause
 	b.WriteString(" FROM ")
@@ -44,6 +37,12 @@ func (c *PostgresConnector) BuildSelect(_ context.Context, req connector.SelectR
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause

--- a/internal/connector/snowflake/query_builder.go
+++ b/internal/connector/snowflake/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -23,15 +24,7 @@ func (c *SnowflakeConnector) BuildSelect(_ context.Context, req connector.Select
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause
 	b.WriteString(" FROM ")
@@ -43,6 +36,12 @@ func (c *SnowflakeConnector) BuildSelect(_ context.Context, req connector.Select
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause

--- a/internal/connector/sqlite/aggregate_select_test.go
+++ b/internal/connector/sqlite/aggregate_select_test.go
@@ -1,0 +1,89 @@
+package sqlite
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/faucetdb/faucet/internal/connector"
+	"github.com/faucetdb/faucet/internal/query"
+)
+
+// TestBuildSelectAggregates verifies GROUP BY and aggregate projection
+// rendering, including ordering by an aggregate's alias.
+func TestBuildSelectAggregates(t *testing.T) {
+	c := newTestConnector()
+
+	tests := []struct {
+		name     string
+		req      connector.SelectRequest
+		wantSQL  string
+		wantArgs []interface{}
+	}{
+		{
+			name: "group by with sum aggregate",
+			req: connector.SelectRequest{
+				Table: "invoices",
+				Projection: []query.SelectItem{
+					{Column: "region"},
+					{Func: "SUM", Column: "amount", Alias: "sum_amount"},
+				},
+				GroupBy: []string{"region"},
+			},
+			wantSQL: `SELECT "region", SUM("amount") AS "sum_amount" FROM "invoices" GROUP BY "region"`,
+		},
+		{
+			name: "count star grouped, ordered by alias, with limit",
+			req: connector.SelectRequest{
+				Table: "invoices",
+				Projection: []query.SelectItem{
+					{Column: "status"},
+					{Func: "COUNT", Column: "*", Alias: "count"},
+				},
+				GroupBy: []string{"status"},
+				Order:   `"count" DESC`,
+				Limit:   5,
+			},
+			wantSQL:  `SELECT "status", COUNT(*) AS "count" FROM "invoices" GROUP BY "status" ORDER BY "count" DESC LIMIT ?`,
+			wantArgs: []interface{}{5},
+		},
+		{
+			name: "whole-table aggregate without group",
+			req: connector.SelectRequest{
+				Table: "invoices",
+				Projection: []query.SelectItem{
+					{Func: "SUM", Column: "amount", Alias: "sum_amount"},
+				},
+			},
+			wantSQL: `SELECT SUM("amount") AS "sum_amount" FROM "invoices"`,
+		},
+		{
+			name: "multi-column group by",
+			req: connector.SelectRequest{
+				Table: "invoices",
+				Projection: []query.SelectItem{
+					{Column: "region"},
+					{Column: "status"},
+					{Func: "AVG", Column: "amount", Alias: "avg_amount"},
+				},
+				GroupBy: []string{"region", "status"},
+			},
+			wantSQL: `SELECT "region", "status", AVG("amount") AS "avg_amount" FROM "invoices" GROUP BY "region", "status"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSQL, gotArgs, err := c.BuildSelect(context.Background(), tt.req)
+			if err != nil {
+				t.Fatalf("BuildSelect() unexpected error: %v", err)
+			}
+			if gotSQL != tt.wantSQL {
+				t.Errorf("SQL =\n  %s\nwant\n  %s", gotSQL, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("args = %#v, want %#v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/connector/sqlite/query_builder.go
+++ b/internal/connector/sqlite/query_builder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/faucetdb/faucet/internal/connector"
 	"github.com/faucetdb/faucet/internal/model"
+	"github.com/faucetdb/faucet/internal/query"
 )
 
 // BuildSelect constructs a SELECT query from the given request.
@@ -22,15 +23,7 @@ func (c *SQLiteConnector) BuildSelect(_ context.Context, req connector.SelectReq
 
 	// SELECT clause
 	b.WriteString("SELECT ")
-	if len(req.Fields) > 0 {
-		quoted := make([]string, len(req.Fields))
-		for i, f := range req.Fields {
-			quoted[i] = c.QuoteIdentifier(f)
-		}
-		b.WriteString(strings.Join(quoted, ", "))
-	} else {
-		b.WriteString("*")
-	}
+	b.WriteString(query.BuildSelectList(req.Projection, req.Fields, c.QuoteIdentifier))
 
 	// FROM clause — SQLite doesn't use schema-qualified names for the main db
 	b.WriteString(" FROM ")
@@ -40,6 +33,12 @@ func (c *SQLiteConnector) BuildSelect(_ context.Context, req connector.SelectReq
 	if req.Filter != "" {
 		b.WriteString(" WHERE ")
 		b.WriteString(req.Filter)
+	}
+
+	// GROUP BY clause
+	if gb := query.BuildGroupBy(req.GroupBy, c.QuoteIdentifier); gb != "" {
+		b.WriteString(" ")
+		b.WriteString(gb)
 	}
 
 	// ORDER BY clause

--- a/internal/handler/openapi.go
+++ b/internal/handler/openapi.go
@@ -458,7 +458,13 @@ func buildQueryParameters() []map[string]interface{} {
 		{
 			"name":        "fields",
 			"in":          "query",
-			"description": "Comma-separated list of fields to return",
+			"description": "Comma-separated list of fields to return; each may be a plain column or an aggregate such as SUM(amount), COUNT(*), or AVG(price) AS avg_price",
+			"schema":      map[string]interface{}{"type": "string"},
+		},
+		{
+			"name":        "group",
+			"in":          "query",
+			"description": "Comma-separated columns to group by (e.g. 'region,status'); combine with aggregates in 'fields'",
 			"schema":      map[string]interface{}{"type": "string"},
 		},
 		{

--- a/internal/handler/table.go
+++ b/internal/handler/table.go
@@ -70,20 +70,38 @@ func (h *TableHandler) QueryRecords(w http.ResponseWriter, r *http.Request) {
 	// Parse query parameters.
 	filterStr := queryString(r, "filter")
 	fieldsStr := queryString(r, "fields")
+	groupStr := queryString(r, "group")
 	orderStr := queryString(r, "order")
 	idsStr := queryString(r, "ids")
 	limit := clampInt(queryInt(r, "limit", 25), 0, 1000)
 	offset := queryInt(r, "offset", 0)
 	includeCount := queryBool(r, "include_count")
 
-	// Validate and parse fields.
-	var fields []string
+	// Parse the projection (plain columns and/or aggregates like SUM(amount)).
+	var projection []query.SelectItem
 	if fieldsStr != "" {
-		fields, err = query.ParseFieldSelection(fieldsStr)
+		projection, err = query.ParseProjection(fieldsStr)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "Invalid fields parameter: "+err.Error())
 			return
 		}
+	}
+
+	// Parse GROUP BY columns.
+	var groupBy []string
+	if groupStr != "" {
+		groupBy, err = query.ParseGroupBy(groupStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid group parameter: "+err.Error())
+			return
+		}
+	}
+
+	// Reject projections that mix aggregates and plain columns inconsistently,
+	// so the SQL is well-defined and portable across dialects.
+	if err := query.ValidateGroupedProjection(projection, groupBy); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	// Parse and parameterize the filter expression.
@@ -136,10 +154,11 @@ func (h *TableHandler) QueryRecords(w http.ResponseWriter, r *http.Request) {
 	// Build and execute the SELECT query.
 	selectReq := connector.SelectRequest{
 		Table:      tableName,
-		Fields:     fields,
+		Projection: projection,
 		Filter:     filterSQL,
 		FilterArgs: filterParams,
 		Order:      orderSQL,
+		GroupBy:    groupBy,
 		Limit:      limit,
 		Offset:     offset,
 	}
@@ -196,9 +215,10 @@ func (h *TableHandler) QueryRecords(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Optionally fetch total count.
+	// Optionally fetch total count. Skipped for grouped queries, where a plain
+	// COUNT(*) would count underlying rows rather than result groups.
 	var total *int64
-	if includeCount {
+	if includeCount && len(groupBy) == 0 {
 		countReq := connector.CountRequest{
 			Table:  tableName,
 			Filter: filterSQL,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -97,8 +97,14 @@ func (s *MCPServer) registerTools(srv *server.MCPServer) {
 				mcp.Description("Filter expression (e.g. \"status = 'active' AND age > 21\")"),
 			),
 			mcp.WithArray("fields",
-				mcp.Description("List of column names to return. Omit for all columns."),
+				mcp.Description("List of columns to return, each either a plain column or an "+
+					"aggregate such as \"SUM(amount)\", \"COUNT(*)\", or \"AVG(price) AS avg_price\". "+
+					"Omit for all columns."),
 				mcp.WithStringItems(),
+			),
+			mcp.WithString("group",
+				mcp.Description("Comma-separated columns to GROUP BY (e.g. \"region,status\"). "+
+					"Aggregate in 'fields' to compute per group; order by an aggregate's alias."),
 			),
 			mcp.WithString("order",
 				mcp.Description("Order clause (e.g. \"created_at DESC, name ASC\")"),
@@ -385,6 +391,7 @@ func (s *MCPServer) handleQuery(
 
 	filterStr := optionalString(request, "filter")
 	fields := optionalStringSlice(request, "fields")
+	groupStr := optionalString(request, "group")
 	orderStr := optionalString(request, "order")
 	limit := clamp(optionalInt(request, "limit", 25), 1, 1000)
 	offset := optionalInt(request, "offset", 0)
@@ -398,9 +405,10 @@ func (s *MCPServer) handleQuery(
 			serviceName, s.registry.ListServices())
 	}
 
-	// Parse and validate fields.
+	// Parse the projection (plain columns and/or aggregates).
+	var projection []query.SelectItem
 	if len(fields) > 0 {
-		validated, err := query.ParseFieldSelection(strings.Join(fields, ","))
+		projection, err = query.ParseProjection(strings.Join(fields, ","))
 		if err != nil {
 			tableSchema, _ := conn.IntrospectTable(ctx, tableName)
 			var colNames []string
@@ -411,7 +419,19 @@ func (s *MCPServer) handleQuery(
 			}
 			return toolError("Invalid fields: %v\n\nAvailable columns: %v", err, colNames)
 		}
-		fields = validated
+	}
+
+	// Parse GROUP BY columns and validate aggregate/group consistency.
+	var groupBy []string
+	if groupStr != "" {
+		groupBy, err = query.ParseGroupBy(groupStr)
+		if err != nil {
+			return toolError("Invalid group clause: %v\n\n"+
+				"Group syntax: column[,column...]  (e.g. region,status)", err)
+		}
+	}
+	if err := query.ValidateGroupedProjection(projection, groupBy); err != nil {
+		return toolError("%v", err)
 	}
 
 	// Parse filter expression into parameterized SQL.
@@ -451,10 +471,11 @@ func (s *MCPServer) handleQuery(
 	// Build and execute the query.
 	selectReq := connector.SelectRequest{
 		Table:      tableName,
-		Fields:     fields,
+		Projection: projection,
 		Filter:     filterSQL,
 		FilterArgs: filterParams,
 		Order:      orderSQL,
+		GroupBy:    groupBy,
 		Limit:      limit,
 		Offset:     offset,
 	}
@@ -518,7 +539,7 @@ func (s *MCPServer) handleInsert(
 
 	records := getObjectSliceArg(request, "records")
 	if len(records) == 0 {
-		return toolError("No records provided. The 'records' parameter must be an array "+
+		return toolError("No records provided. The 'records' parameter must be an array " +
 			"of objects, e.g. [{\"name\": \"Alice\", \"age\": 30}]")
 	}
 
@@ -603,7 +624,7 @@ func (s *MCPServer) handleUpdate(
 	}
 	filterStr, err := requireString(request, "filter")
 	if err != nil {
-		return toolError("A filter is required for update operations to prevent "+
+		return toolError("A filter is required for update operations to prevent " +
 			"accidental full-table updates. Example: id = 42")
 	}
 
@@ -615,7 +636,7 @@ func (s *MCPServer) handleUpdate(
 
 	record := getObjectArg(request, "record")
 	if len(record) == 0 {
-		return toolError("No fields to update. The 'record' parameter must be an object "+
+		return toolError("No fields to update. The 'record' parameter must be an object " +
 			"with column names and values, e.g. {\"status\": \"archived\"}")
 	}
 
@@ -710,7 +731,7 @@ func (s *MCPServer) handleDelete(
 	}
 	filterStr, err := requireString(request, "filter")
 	if err != nil {
-		return toolError("A filter is required for delete operations to prevent "+
+		return toolError("A filter is required for delete operations to prevent " +
 			"accidental full-table deletes. Example: id = 42")
 	}
 

--- a/internal/openapi/generator.go
+++ b/internal/openapi/generator.go
@@ -706,7 +706,15 @@ func listQueryParameters() openapi3.Parameters {
 		},
 		&openapi3.ParameterRef{
 			Value: openapi3.NewQueryParameter("fields").
-				WithDescription("Comma-separated list of fields to include in the response.").
+				WithDescription("Comma-separated list of fields to include in the response. " +
+					"Each field may be a plain column or an aggregate such as \"SUM(amount)\", " +
+					"\"COUNT(*)\", or \"AVG(price) AS avg_price\". Combine with 'group' to aggregate per group.").
+				WithSchema(openapi3.NewStringSchema()),
+		},
+		&openapi3.ParameterRef{
+			Value: openapi3.NewQueryParameter("group").
+				WithDescription("Comma-separated columns to group by (e.g. \"region,status\"). " +
+					"Use aggregates in 'fields' to compute per-group values; order by an aggregate's alias.").
 				WithSchema(openapi3.NewStringSchema()),
 		},
 		&openapi3.ParameterRef{

--- a/internal/query/aggregate.go
+++ b/internal/query/aggregate.go
@@ -1,0 +1,223 @@
+package query
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// aggregateFuncs is the allowlist of SQL aggregate functions permitted in a
+// fields= projection. The rendered function name is always taken from this
+// fixed set (never from user input verbatim), so it cannot be a vector for
+// SQL injection.
+var aggregateFuncs = map[string]bool{
+	"SUM":   true,
+	"COUNT": true,
+	"AVG":   true,
+	"MIN":   true,
+	"MAX":   true,
+}
+
+// aggregateRegex matches a single aggregate projection element such as
+// "SUM(amount)", "COUNT(*)", or "AVG(price) AS avg_price".
+// Submatches: 1 = function name, 2 = column or "*", 3 = optional alias.
+var aggregateRegex = regexp.MustCompile(
+	`(?i)^([a-z]+)\(\s*(\*|[a-z_][a-z0-9_]*)\s*\)(?:\s+as\s+([a-z_][a-z0-9_]*))?$`,
+)
+
+// SelectItem is one entry in a SELECT projection. A plain column has an empty
+// Func; an aggregate has Func set to an allowlisted function name (uppercased),
+// Column set to the argument ("*" only for COUNT), and Alias set to the output
+// column name.
+type SelectItem struct {
+	Func   string
+	Column string
+	Alias  string
+}
+
+// IsAggregate reports whether this item is an aggregate expression.
+func (s SelectItem) IsAggregate() bool { return s.Func != "" }
+
+// ParseProjection parses a comma-separated fields list that may mix plain
+// columns with aggregate expressions, e.g. "region,SUM(amount) AS total".
+// Plain columns and aggregate arguments are validated as SQL identifiers.
+// Returns nil for an empty input string (the caller then selects all columns).
+func ParseProjection(fields string) ([]SelectItem, error) {
+	fields = strings.TrimSpace(fields)
+	if fields == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(fields, ",")
+	items := make([]SelectItem, 0, len(parts))
+
+	for _, raw := range parts {
+		part := strings.TrimSpace(raw)
+		if part == "" {
+			continue
+		}
+
+		if m := aggregateRegex.FindStringSubmatch(part); m != nil {
+			fn := strings.ToUpper(m[1])
+			if !aggregateFuncs[fn] {
+				return nil, fmt.Errorf("unsupported aggregate function %q: allowed functions are AVG, COUNT, MAX, MIN, SUM", m[1])
+			}
+			arg := m[2]
+			if arg == "*" && fn != "COUNT" {
+				return nil, fmt.Errorf("%s(*) is not allowed; only COUNT supports the * argument", fn)
+			}
+			if arg != "*" {
+				if err := ValidateIdentifier(arg); err != nil {
+					return nil, fmt.Errorf("invalid aggregate column: %w", err)
+				}
+			}
+			alias := m[3]
+			if alias == "" {
+				alias = defaultAlias(fn, arg)
+			}
+			if err := ValidateIdentifier(alias); err != nil {
+				return nil, fmt.Errorf("invalid aggregate alias: %w", err)
+			}
+			items = append(items, SelectItem{Func: fn, Column: arg, Alias: alias})
+			continue
+		}
+
+		// Plain column.
+		if err := ValidateIdentifier(part); err != nil {
+			return nil, fmt.Errorf("invalid field name: %w", err)
+		}
+		items = append(items, SelectItem{Column: part})
+	}
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items, nil
+}
+
+// defaultAlias derives a deterministic output name for an aggregate that has no
+// explicit alias: "count" for COUNT(*), otherwise "<func>_<column>" lowercased,
+// e.g. SUM(amount) -> "sum_amount".
+func defaultAlias(fn, arg string) string {
+	if arg == "*" {
+		return strings.ToLower(fn)
+	}
+	return strings.ToLower(fn) + "_" + arg
+}
+
+// HasAggregate reports whether any item in the projection is an aggregate.
+func HasAggregate(items []SelectItem) bool {
+	for _, it := range items {
+		if it.IsAggregate() {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateGroupedProjection enforces that a projection mixing aggregates with
+// plain columns is well-formed and portable across SQL dialects:
+//   - if a GROUP BY is present, every plain (non-aggregated) column must appear
+//     in it;
+//   - if an aggregate is present without a GROUP BY, no plain columns may be
+//     selected alongside it (a bare column next to an aggregate is undefined in
+//     standard SQL and silently picks an arbitrary row in SQLite);
+//   - a GROUP BY requires an explicit fields list (no implicit SELECT *).
+func ValidateGroupedProjection(items []SelectItem, groupBy []string) error {
+	hasGroup := len(groupBy) > 0
+	hasAgg := HasAggregate(items)
+	if !hasGroup && !hasAgg {
+		return nil
+	}
+	if hasGroup && len(items) == 0 {
+		return fmt.Errorf("group parameter requires an explicit fields list")
+	}
+
+	groupSet := make(map[string]bool, len(groupBy))
+	for _, g := range groupBy {
+		groupSet[g] = true
+	}
+	for _, it := range items {
+		if it.IsAggregate() {
+			continue
+		}
+		if !groupSet[it.Column] {
+			return fmt.Errorf("column %q must be wrapped in an aggregate function or listed in the group parameter", it.Column)
+		}
+	}
+	return nil
+}
+
+// BuildProjection renders a projection into a SQL select list, quoting all
+// identifiers with quoteFn. Aggregates render as FUNC(col) AS "alias".
+func BuildProjection(items []SelectItem, quoteFn func(string) string) string {
+	parts := make([]string, len(items))
+	for i, it := range items {
+		if !it.IsAggregate() {
+			parts[i] = quoteFn(it.Column)
+			continue
+		}
+		inner := "*"
+		if it.Column != "*" {
+			inner = quoteFn(it.Column)
+		}
+		parts[i] = it.Func + "(" + inner + ") AS " + quoteFn(it.Alias)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// BuildSelectList renders the SELECT list for a query. A structured projection
+// takes precedence; otherwise the plain field list is quoted; an empty field
+// list yields "*". This preserves the original field-selection behavior while
+// adding aggregate support.
+func BuildSelectList(projection []SelectItem, fields []string, quoteFn func(string) string) string {
+	if len(projection) > 0 {
+		return BuildProjection(projection, quoteFn)
+	}
+	if len(fields) > 0 {
+		quoted := make([]string, len(fields))
+		for i, f := range fields {
+			quoted[i] = quoteFn(f)
+		}
+		return strings.Join(quoted, ", ")
+	}
+	return "*"
+}
+
+// ParseGroupBy parses a comma-separated list of column names for a GROUP BY
+// clause, validating each as a SQL identifier. Returns nil for empty input.
+func ParseGroupBy(group string) ([]string, error) {
+	group = strings.TrimSpace(group)
+	if group == "" {
+		return nil, nil
+	}
+	parts := strings.Split(group, ",")
+	cols := make([]string, 0, len(parts))
+	for _, raw := range parts {
+		col := strings.TrimSpace(raw)
+		if col == "" {
+			continue
+		}
+		if err := ValidateIdentifier(col); err != nil {
+			return nil, fmt.Errorf("invalid group column: %w", err)
+		}
+		cols = append(cols, col)
+	}
+	if len(cols) == 0 {
+		return nil, nil
+	}
+	return cols, nil
+}
+
+// BuildGroupBy renders a GROUP BY clause (without a leading space), quoting each
+// column with quoteFn. Returns "" when there are no columns.
+func BuildGroupBy(cols []string, quoteFn func(string) string) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(cols))
+	for i, c := range cols {
+		quoted[i] = quoteFn(c)
+	}
+	return "GROUP BY " + strings.Join(quoted, ", ")
+}

--- a/internal/query/aggregate_test.go
+++ b/internal/query/aggregate_test.go
@@ -1,0 +1,229 @@
+package query
+
+import (
+	"reflect"
+	"testing"
+)
+
+// dqQuote is a test double for a dialect quote function (double-quote style).
+func dqQuote(s string) string { return `"` + s + `"` }
+
+func TestParseProjection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []SelectItem
+		wantErr bool
+	}{
+		{
+			name:  "empty returns nil",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "plain columns",
+			input: "id,name,email",
+			want: []SelectItem{
+				{Column: "id"},
+				{Column: "name"},
+				{Column: "email"},
+			},
+		},
+		{
+			name:  "sum aggregate with default alias",
+			input: "SUM(amount)",
+			want:  []SelectItem{{Func: "SUM", Column: "amount", Alias: "sum_amount"}},
+		},
+		{
+			name:  "count star with default alias",
+			input: "COUNT(*)",
+			want:  []SelectItem{{Func: "COUNT", Column: "*", Alias: "count"}},
+		},
+		{
+			name:  "explicit alias",
+			input: "AVG(price) AS avg_price",
+			want:  []SelectItem{{Func: "AVG", Column: "price", Alias: "avg_price"}},
+		},
+		{
+			name:  "lowercase function name is normalized",
+			input: "min(score)",
+			want:  []SelectItem{{Func: "MIN", Column: "score", Alias: "min_score"}},
+		},
+		{
+			name:  "mixed plain and aggregate preserves order",
+			input: "region, SUM(amount) AS total, COUNT(*)",
+			want: []SelectItem{
+				{Column: "region"},
+				{Func: "SUM", Column: "amount", Alias: "total"},
+				{Func: "COUNT", Column: "*", Alias: "count"},
+			},
+		},
+		{
+			name:  "whitespace inside parens is tolerated",
+			input: "MAX(  amount  )",
+			want:  []SelectItem{{Func: "MAX", Column: "amount", Alias: "max_amount"}},
+		},
+		{
+			name:    "unknown aggregate function rejected",
+			input:   "TOTAL(amount)",
+			wantErr: true,
+		},
+		{
+			name:    "star only allowed for COUNT",
+			input:   "SUM(*)",
+			wantErr: true,
+		},
+		{
+			name:    "reserved word as alias rejected",
+			input:   "SUM(amount) AS select",
+			wantErr: true,
+		},
+		{
+			name:    "injection in aggregate argument rejected",
+			input:   "SUM(1); DROP TABLE users--)",
+			wantErr: true,
+		},
+		{
+			name:    "injection masquerading as column rejected",
+			input:   "id; DROP TABLE users",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseProjection(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseProjection(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseProjection(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateGroupedProjection(t *testing.T) {
+	tests := []struct {
+		name    string
+		items   []SelectItem
+		groupBy []string
+		wantErr bool
+	}{
+		{
+			name:  "no aggregate no group is fine",
+			items: []SelectItem{{Column: "id"}, {Column: "name"}},
+		},
+		{
+			name:  "whole-table aggregate without group is fine",
+			items: []SelectItem{{Func: "SUM", Column: "amount", Alias: "sum_amount"}},
+		},
+		{
+			name:    "aggregate beside bare column without group is rejected",
+			items:   []SelectItem{{Column: "region"}, {Func: "SUM", Column: "amount", Alias: "sum_amount"}},
+			wantErr: true,
+		},
+		{
+			name:    "grouped query with the bare column listed is fine",
+			items:   []SelectItem{{Column: "region"}, {Func: "SUM", Column: "amount", Alias: "sum_amount"}},
+			groupBy: []string{"region"},
+		},
+		{
+			name:    "bare column missing from group is rejected",
+			items:   []SelectItem{{Column: "region"}, {Column: "city"}, {Func: "COUNT", Column: "*", Alias: "count"}},
+			groupBy: []string{"region"},
+			wantErr: true,
+		},
+		{
+			name:    "group without any fields is rejected",
+			items:   nil,
+			groupBy: []string{"region"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGroupedProjection(tt.items, tt.groupBy)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateGroupedProjection() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildProjection(t *testing.T) {
+	items := []SelectItem{
+		{Column: "region"},
+		{Func: "SUM", Column: "amount", Alias: "sum_amount"},
+		{Func: "COUNT", Column: "*", Alias: "count"},
+	}
+	got := BuildProjection(items, dqQuote)
+	want := `"region", SUM("amount") AS "sum_amount", COUNT(*) AS "count"`
+	if got != want {
+		t.Errorf("BuildProjection() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildSelectList(t *testing.T) {
+	tests := []struct {
+		name       string
+		projection []SelectItem
+		fields     []string
+		want       string
+	}{
+		{
+			name: "empty yields star",
+			want: "*",
+		},
+		{
+			name:   "plain fields fallback preserves legacy behavior",
+			fields: []string{"id", "name"},
+			want:   `"id", "name"`,
+		},
+		{
+			name:       "projection takes precedence over fields",
+			projection: []SelectItem{{Func: "SUM", Column: "amount", Alias: "sum_amount"}},
+			fields:     []string{"ignored"},
+			want:       `SUM("amount") AS "sum_amount"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BuildSelectList(tt.projection, tt.fields, dqQuote); got != tt.want {
+				t.Errorf("BuildSelectList() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGroupBy(t *testing.T) {
+	got, err := ParseGroupBy("region, status")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"region", "status"}) {
+		t.Errorf("ParseGroupBy() = %#v", got)
+	}
+
+	if _, err := ParseGroupBy(""); err != nil {
+		t.Errorf("empty group should not error, got %v", err)
+	}
+	if _, err := ParseGroupBy("region; DROP TABLE x"); err == nil {
+		t.Errorf("expected error for injection attempt in group")
+	}
+}
+
+func TestBuildGroupBy(t *testing.T) {
+	if got := BuildGroupBy(nil, dqQuote); got != "" {
+		t.Errorf("BuildGroupBy(nil) = %q, want empty", got)
+	}
+	got := BuildGroupBy([]string{"region", "created_at"}, dqQuote)
+	want := `GROUP BY "region", "created_at"`
+	if got != want {
+		t.Errorf("BuildGroupBy() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Adds **aggregate functions and `GROUP BY`** to the table query API. Callers can now
request `SUM`/`COUNT`/`AVG`/`MIN`/`MAX` in `fields` and group with a new `group`
parameter, computing per-group results server-side instead of paging the whole
table and aggregating in the client.

```
GET /api/v1/<service>/_table/<table>
      ?fields=region,SUM(amount) AS total,COUNT(*)
      &group=region
      &order=total desc
      &filter=status='open'
```

```json
{ "resource": [ { "region": "north", "total": 48210, "count": 7 }, ... ] }
```

- Aggregates also work without a group (whole-table rollups): `fields=SUM(amount)`.
- Order by an aggregate's alias. Default alias is `<func>_<column>` (e.g. `sum_amount`),
  or `count` for `COUNT(*)`; override with `... AS alias`.
- Works the same over the MCP `faucet_query` tool (new `group` argument).

## Why

Today the only way to answer "total per customer" or "count by status" is to pull every
matching row and reduce it client-side. For large tables that means many paginated
requests and a lot of transferred JSON to produce a handful of numbers. The aggregation
is pushed down to the database where it belongs.

## Design & safety

- New `internal/query/aggregate.go`: `ParseProjection` turns a mixed plain/aggregate
  field list into `[]SelectItem`; `BuildSelectList`/`BuildGroupBy` render the SQL;
  `ValidateGroupedProjection` rejects non-portable queries (a bare column beside an
  aggregate must appear in `GROUP BY`; a `group` requires an explicit field list).
- `connector.SelectRequest` gains `Projection` and `GroupBy`. All six dialect builders
  emit `GROUP BY` between `WHERE` and `ORDER BY` and share the select-list renderer, so
  behavior is consistent across SQLite/Postgres/MySQL/SQL Server/Oracle/Snowflake.
- **No new injection surface.** Aggregate function names come from a fixed allowlist;
  every column and alias is validated with the existing `ValidateIdentifier` and quoted
  with the dialect's quote function. Values remain parameterized. Injection attempts in
  an aggregate argument or alias are rejected with 400.
- `include_count` is skipped for grouped queries (a plain `COUNT(*)` would count
  underlying rows, not result groups).

## Tests

- `internal/query/aggregate_test.go`: projection parsing (plain, all aggregates, default
  + explicit alias, mixed order), the `*`-only-for-COUNT rule, reserved-word aliases,
  injection attempts, grouped-projection validation, and clause rendering.
- `internal/connector/sqlite/aggregate_select_test.go`: end-to-end `BuildSelect` SQL for
  grouped aggregates, alias ordering, multi-column group, and whole-table rollups.
- `make test` (race) green; `golangci-lint run` clean.

## Notes

- This targets `main`; `CONTRIBUTING.md` mentions a `dev` branch but the repo currently
  only has `main` — happy to retarget.
- `HAVING` (filtering on aggregate results) is a natural follow-up and intentionally
  left out to keep this PR focused.
- Verified end-to-end against a large SQLite database (~150k rows): a grouped
  `SUM(...) ... GROUP BY` query that previously required paging the full table and
  reducing client-side now returns the same result in a single request.
